### PR TITLE
:bug: Fix menu CSON indentation.

### DIFF
--- a/menus/sass-director.cson
+++ b/menus/sass-director.cson
@@ -1,38 +1,38 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
-'atom-text-editor': [
-    {
-        'label': 'Toggle sass-director'
-        'command': 'sass-director:toggle'
-    }
-]
-'menu': [
-    {
-        'label': 'Packages'
-        'submenu': [
-            'label': 'Sass Director'
+    'atom-text-editor': [
+        {
+            'label': 'Toggle sass-director'
+            'command': 'sass-director:toggle'
+        }
+    ]
+    'menu': [
+        {
+            'label': 'Packages'
             'submenu': [
-                {
-                    'label': 'Toggle'
-                    'command': 'sass-director:toggle'
-                }
-                {
-                    'label': 'Add Manifest File'
-                    'command': 'sass-director:add-manifest-file'
-                }
-                {
-                    'label': 'Remove Manifest'
-                    'command': 'sass-director:remove-manifest-file'
-                }
-                {
-                    'label': 'Generate'
-                    'command': 'sass-director:generate'
-                }
+                'label': 'Sass Director'
+                'submenu': [
+                    {
+                        'label': 'Toggle'
+                        'command': 'sass-director:toggle'
+                    }
+                    {
+                        'label': 'Add Manifest File'
+                        'command': 'sass-director:add-manifest-file'
+                    }
+                    {
+                        'label': 'Remove Manifest'
+                        'command': 'sass-director:remove-manifest-file'
+                    }
+                    {
+                        'label': 'Generate'
+                        'command': 'sass-director:generate'
+                    }
+                ]
             ]
-        ]
-    }
-]
-'fileTypes': [
-    'sass'
-    'scss'
-]
+        }
+    ]
+    'fileTypes': [
+        'sass'
+        'scss'
+    ]


### PR DESCRIPTION
The current `menus/sass-director.cson` file is improperly indented, causing Atom to throw an error about an unexpected newline (q.v. atom/atom#5495). This PR correctly nests the preexisting menu objects under `'context-menu'`, calming Atom down considerably.
